### PR TITLE
fixed deprecated body request option

### DIFF
--- a/src/Gufy/Whmcs/Whmcs.php
+++ b/src/Gufy/Whmcs/Whmcs.php
@@ -37,11 +37,11 @@ class Whmcs
 		$client = new Client(['defaults' => ['headers' => ['User-Agent' => null]]]);
 		try
 		{
-			$response = $client->post($url, ['body'=>$params,'timeout' => 1200,'connect_timeout' => 10]);
+			$response = $client->post($url, ['form_params' => $params,'timeout' => 1200,'connect_timeout' => 10]);
 
 			try
 			{
-				return $this->processResponse($response->json());
+				return $this->processResponse(json_decode($response->getBody(), true));
 			}
 			catch(ParseException $e)
 			{


### PR DESCRIPTION
Using Guzzle 6 gives the following error:
`Passing in the "body" request option as an array to send a POST request has been deprecated. Please use the "form_params" request option to send a application/x-www-form-urlencoded request, or a the "multipart" request option to send a multipart/form-data request.`

Changed the request option to "form_params" and replaced the ->json method who doesn't exists anymore in Guzzle 6.